### PR TITLE
Create Add again Rank-up-magic numeron force (Anime)

### DIFF
--- a/Add again Rank-up-magic numeron force (Anime)
+++ b/Add again Rank-up-magic numeron force (Anime)
@@ -1,0 +1,247 @@
+Link To Yugipedia : https://yugipedia.com/wiki/Rank-Up-Magic_Numeron_Force_(anime)
+The old script text
+--RUM－ヌメロン・フォース
+
+function c120000026.initial_effect(c)
+
+	--Activate	local e1=Effect.CreateEffect(c)
+
+	e1:SetCategory(CATEGORY_SPECIAL_SUMMON)
+
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+
+	e1:SetCode(EVENT_FREE_CHAIN)
+
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+
+	e1:SetTarget(c120000026.target)
+
+	e1:SetOperation(c120000026.activate)
+
+	c:RegisterEffect(e1)
+
+end
+
+function c120000026.filter1(c,e,tp)
+
+	local rk=c:GetRank()
+
+	return c:IsFaceup() and c:IsType(TYPE_XYZ)
+
+		and Duel.IsExistingMatchingCard(c120000026.filter2,tp,LOCATION_EXTRA,0,1,nil,e,tp,c,rk+1,c:GetCode())
+
+end
+
+function c120000026.filter2(c,e,tp,mc,rk,code)
+
+	if c.rum_limit_code and code~=c.rum_limit_code then return false end
+
+	return c:GetRank()==rk and c:IsSetCard(0x1048) or c:IsSetCard(0x1073) and mc:IsCanBeXyzMaterial(c)
+
+		and c:IsCanBeSpecialSummoned(e,SUMMON_TYPE_XYZ,tp,false,false)
+
+end
+
+function c120000026.disfilter(c)
+
+	return (not c:IsDisabled() or c:IsType(TYPE_TRAPMONSTER)) and not (c:IsType(TYPE_NORMAL) and bit.band(c:GetOriginalType(),TYPE_NORMAL))
+
+end
+
+function c120000026.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+
+	if chkc then return chkc:IsControler(tp) and chkc:IsLocation(LOCATION_MZONE) and c120000026.filter1(chkc,e,tp) end
+
+	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>-1
+
+		and Duel.IsExistingTarget(c120000026.filter1,tp,LOCATION_MZONE,0,1,nil,e,tp) end
+
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_XMATERIAL)
+
+	local g=Duel.SelectTarget(tp,c120000026.filter1,tp,LOCATION_MZONE,0,1,1,nil,e,tp)
+
+	local g=Duel.GetMatchingGroup(c120000026.disfilter,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,e:GetHandler())
+
+	tc=g:GetFirst()
+
+	while tc do
+
+		local e1=Effect.CreateEffect(e:GetHandler())
+
+		e1:SetType(EFFECT_TYPE_SINGLE)
+
+		e1:SetCode(EFFECT_DISABLE)
+
+		e1:SetReset(RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END)
+
+		tc:RegisterEffect(e1)
+
+		local e2=Effect.CreateEffect(e:GetHandler())
+
+		e2:SetType(EFFECT_TYPE_SINGLE)
+
+		e2:SetCode(EFFECT_DISABLE_EFFECT)
+
+		e2:SetReset(RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END)
+
+		tc:RegisterEffect(e2)
+
+		tc=g:GetNext()
+
+	end
+
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_EXTRA)
+
+end
+
+function c120000026.activate(e,tp,eg,ep,ev,re,r,rp)
+
+	if Duel.GetLocationCount(tp,LOCATION_MZONE)<0 then return end
+
+	local c=e:GetHandler()
+
+	local tc=Duel.GetFirstTarget()
+
+	if tc:IsFacedown() or not tc:IsRelateToEffect(e) or tc:IsControler(1-tp) or tc:IsImmuneToEffect(e) then return end
+
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+
+	local g=Duel.SelectMatchingCard(tp,c120000026.filter2,tp,LOCATION_EXTRA,0,1,1,nil,e,tp,tc,tc:GetRank()+1,tc:GetCode())
+
+	local sc=g:GetFirst()
+
+	if sc then
+
+		local mg=tc:GetOverlayGroup()
+
+		if mg:GetCount()~=0 then
+
+			Duel.Overlay(sc,mg)
+
+		end
+
+		sc:SetMaterial(Group.FromCards(tc))
+
+		Duel.Overlay(sc,Group.FromCards(tc))
+
+		Duel.SpecialSummon(sc,SUMMON_TYPE_XYZ,tp,tp,false,false,POS_FACEUP)
+
+			Duel.SpecialSummonStep(sc,SUMMON_TYPE_XYZ,tp,tp,true,false,POS_FACEUP)
+
+			local e1=Effect.CreateEffect(e:GetHandler())
+
+			e1:SetProperty(EFFECT_FLAG_INITIAL)
+
+			e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
+
+			e1:SetCode(EVENT_BATTLED)
+
+			e1:SetRange(LOCATION_MZONE)
+
+			e1:SetCondition(c120000026.con)
+
+			e1:SetOperation(c120000026.op)
+
+			e1:SetReset(RESET_EVENT+0x1fe0000)
+
+			sc:RegisterEffect(e1)
+
+			local e2=Effect.CreateEffect(e:GetHandler())
+
+			e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
+
+			e2:SetCode(EVENT_ATTACK_ANNOUNCE)
+
+			e2:SetOperation(c120000026.oop)
+
+			e2:SetReset(RESET_EVENT+0x1fe0000)
+
+			sc:RegisterEffect(e2)
+
+			sc:RegisterFlagEffect(120000026,RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END,0,1)
+
+			Duel.SpecialSummonComplete()		
+
+			sc:CompleteProcedure()
+
+	end
+
+end
+
+function c120000026.con(e)
+
+	local c=e:GetHandler()
+
+	local atk=c:GetAttack()
+
+	local bc=c:GetBattleTarget()
+
+	if not bc then return end
+
+	local bct=0
+
+	if bc:GetPosition()==POS_FACEUP_ATTACK then
+
+		bct=bc:GetAttack()
+
+	else bct=bc:GetDefense()+1 end
+
+	return c:IsRelateToBattle() and c:GetPosition()==POS_FACEUP_ATTACK 
+
+	 and atk>=bct and not bc:IsStatus(STATUS_BATTLE_DESTROYED)
+
+end
+
+function c120000026.op(e,tp,eg,ep,ev,re,r,rp)
+
+	local bc=e:GetHandler():GetBattleTarget()
+
+	if Duel.Destroy(bc,REASON_BATTLE) then Duel.Destroy(bc,REASON_RULE) end
+
+	bc:SetStatus(STATUS_BATTLE_DESTROYED,true)
+
+end
+
+function c120000026.oop(e,tp,eg,ep,ev,re,r,rp)
+
+	local bc=e:GetHandler():GetBattleTarget()
+
+	if bc then
+
+		local e1=Effect.CreateEffect(e:GetHandler())
+
+		e1:SetType(EFFECT_TYPE_SINGLE)
+
+		e1:SetCode(EFFECT_INDESTRUCTABLE_BATTLE)
+
+		e1:SetValue(1)
+
+		e1:SetReset(RESET_EVENT+0x1fe0000)
+
+		bc:RegisterEffect(e1)
+
+		local e2=Effect.CreateEffect(e:GetHandler())
+
+		e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
+
+		e2:SetCode(EVENT_DAMAGE_STEP_END)
+
+		e2:SetLabelObject(e1)
+
+		e2:SetOperation(c120000026.resetop)
+
+		e2:SetReset(RESET_EVENT+0x1fe0000)
+
+		bc:RegisterEffect(e2)
+
+	end
+
+end
+
+function c120000026.resetop(e,tp,eg,ep,ev,re,r,rp)
+
+	e:GetLabelObject():Reset()
+
+	e:Reset()
+
+end


### PR DESCRIPTION
An idea could be to negate spells and trap on the field until this card resolves and then to let the other spell and trap be activable

<!--
Hello, thanks for submitting a pull request! Please provide enough information so we can review it.

If you are submitting an addition to the unofficial script project, the pull request title should be
of the form `Add "CARD NAME"`. Replace this comment with a Yugipedia link.

If you are submitting a bug fix, the pull request title should be of the form `Fix "CARD NAME"`.
In this case, replace this comment with a brief summary of your change. What did you fix?
--->

- [x] I am following the [contributing guidelines](https://github.com/ProjectIgnis/CardScripts/blob/master/CONTRIBUTING.md).

**New card checklist**

- [x] I have submitted a corresponding database entry for [BabelCDB](https://github.com/ProjectIgnis/BabelCDB/blob/master/README.md) according to its guidelines. Link to the pull request: _fill in_
- [x] This card is not marked with a reason to not be added in the unofficial card tracker in `#card-scripting-101`.
Supervising staff member(s): _fill in_
